### PR TITLE
fix test

### DIFF
--- a/src/test/java/client/SsoIT.java
+++ b/src/test/java/client/SsoIT.java
@@ -48,7 +48,7 @@ public class SsoIT {
         authzClient = AuthzClient.create(config);
 
         applicationUrls = routes.stream()
-                .filter(r -> !r.getMetadata().getName().contains("sso"))
+                .filter(r -> r.getMetadata().getName().contains("secured"))
                 .map(r -> "http://" + r.getSpec().getHost())
                 .collect(toList());
 


### PR DESCRIPTION
The test originally assumed, just like the standalone application,
that all available routes that don't contain the word "sso" are
actually applications secured using the SSO server, and hence subject
to testing.

That doesn't necessarily have to be true. E.g. in our CI environment,
there's a Jenkins server running, and the CI dashboard application.
This commit improves how applications to test are selected.
Instead of taking all routes that don't contain the word "sso",
it takes all routes containing the word "secured". Of course that's
not ideal, and we should probably move to selecting by labels,
but it's much better than the original way.