### PR TITLE
avoid Maven warning when used as Git submodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
     <version>21</version>
+    <relativePath/>
   </parent>
   <groupId>org.obsidiantoaster.quickstart</groupId>
   <artifactId>redhat-sso</artifactId>


### PR DESCRIPTION
This Git repo is meant to be used as a Git submodule
of individual booster repositories. Therefore, the parent
directory never contains the `jboss-parent` project,
yet it _does_ contain a Maven project. In such situation,
Maven prints a warning. Setting `<relativePath>` to
an empty string silences that warning.
