### PR TITLE
unignore failing test

### DIFF
--- a/src/test/java/client/SsoIT.java
+++ b/src/test/java/client/SsoIT.java
@@ -8,7 +8,6 @@ import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.ws.rs.ForbiddenException;
@@ -93,7 +92,6 @@ public class SsoIT {
     }
 
     @Test
-    @Ignore
     public void adminUser() {
         String token = authzClient.obtainAccessToken("admin", "admin");
         for (String url : applicationUrls) {


### PR DESCRIPTION
One test in `SsoIT` has been marked `@Ignore` recently because
it's failing. However, it's failing for a reason -- the interaction
that this test verifies no longer behaves appropriately. In other
words, the failure is genuine and needs to be fixed, not ignored.